### PR TITLE
Bugfix: deploy-demo.ymlをpackages構造に対応

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -3,7 +3,7 @@ name: Deploy GitLyte Demo to GitHub Pages
 on:
   push:
     branches: [ main ]
-    paths: ['demo/**', '.github/workflows/deploy-demo.yml']
+    paths: ['packages/demo/**', '.github/workflows/deploy-demo.yml']
   workflow_dispatch:
 
 permissions:
@@ -33,35 +33,25 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/share/pnpm/store
-          key: pnpm-store-demo-${{ runner.os }}-${{ hashFiles('demo/pnpm-lock.yaml') }}
+          key: pnpm-store-demo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             pnpm-store-demo-${{ runner.os }}-
 
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        with:
-          path: demo/node_modules
-          key: node-modules-demo-${{ runner.os }}-${{ hashFiles('demo/pnpm-lock.yaml') }}
-          restore-keys: |
-            node-modules-demo-${{ runner.os }}-
-
-      - name: Install demo dependencies
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        working-directory: demo
 
       - name: Cache Astro build
         uses: actions/cache@v4
         with:
           path: |
-            demo/.astro
-            demo/dist
-          key: astro-build-demo-${{ runner.os }}-${{ hashFiles('demo/src/**/*', 'demo/astro.config.mjs', 'demo/package.json') }}
+            packages/demo/.astro
+            packages/demo/dist
+          key: astro-build-demo-${{ runner.os }}-${{ hashFiles('packages/demo/src/**/*', 'packages/demo/astro.config.mjs', 'packages/demo/package.json') }}
           restore-keys: |
             astro-build-demo-${{ runner.os }}-
 
       - name: Build Astro demo site
-        run: pnpm run build
-        working-directory: demo
+        run: pnpm --filter @gitlyte/demo build
           
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -69,7 +59,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './demo/dist'
+          path: './packages/demo/dist'
 
   deploy:
     environment:


### PR DESCRIPTION
# 概要

packages構造への変更により動作しなくなったdemo deploymentワークフローを修正

## 変更内容

deploy-demo.ymlをpnpm workspaces構造に対応させるための修正を実施

- **トリガーパス修正**: `demo/**` → `packages/demo/**`
- **ビルドコマンド変更**: `pnpm run build` → `pnpm --filter @gitlyte/demo build`
- **キャッシュパス修正**: demo関連のパスをpackages/demo配下に変更
- **アーティファクトパス修正**: `./demo/dist` → `./packages/demo/dist`
- **依存関係インストール統一**: ワークスペース全体での`pnpm install`に変更
- **不要なキャッシュ削除**: 個別のnode_modulesキャッシュステップを削除

## 関連情報

packages構造への移行により、GitHub Pagesデプロイが失敗していた問題を解決

- pnpm workspaceとfilterコマンドの活用
- ワークフロー効率化（キャッシュの最適化）
- packages/demo配下の正しいパス指定