### PR TITLE
Bugfix: workspace依存関係を削除して外部リポジトリのnpmエラーを解決

### DIFF
--- a/packages/gitlyte/services/ai-content-generator.ts
+++ b/packages/gitlyte/services/ai-content-generator.ts
@@ -388,7 +388,6 @@ function generatePackageJson(repoData: RepoData): string {
       },
       dependencies: {
         astro: "^4.0.0",
-        "@gitlyte/shared": "workspace:*",
       },
     },
     null,


### PR DESCRIPTION
# 概要

外部リポジトリでのAstroビルド時に発生していた `npm error code EUNSUPPORTEDPROTOCOL` エラーを解決するため、生成されるpackage.jsonからworkspace依存関係を削除しました。

## 変更内容

- `generatePackageJson`関数で生成されるpackage.jsonから `"@gitlyte/shared": "workspace:*"` 依存関係を削除
- 外部リポジトリでnpmを使用してビルドする際の互換性を向上
- workspace記法はpnpm固有の機能のため、npm環境では認識されずエラーの原因となっていました

## 関連情報

- 外部リポジトリでのnpmビルドエラー `EUNSUPPORTEDPROTOCOL` を解決
- GitLyteが生成するAstroサイトの外部デプロイ時の安定性向上

🤖 Generated with [Claude Code](https://claude.ai/code)