### PR TITLE
New Feature: GitLyteラベルによるPRマージトリガーとラベル自動管理

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,17 @@ A GitHub App built with [Probot](https://github.com/probot/probot) that automati
 - ⚡ **Auto-Deploy**: GitHub Actions automatically build and deploy
 - 🔄 **Flexible Triggers**: Multiple ways to control when sites are generated
 - 💬 **Comment Commands**: Generate sites on-demand with PR comments  
-- 🏷️ **Label Control**: Fine-grained control with GitHub labels
+- 🏷️ **Label Control**: Simple control with `gitlyte` and `gitlyte:preview` labels
 
 ## 🚀 Quick Start
 
 1. **Install the GitLyte GitHub App** on your repository
-2. **Push to your main branch** → Your site is automatically generated!
-3. **Enable GitHub Pages** → Go to Settings > Pages > Source: Deploy from a branch → Branch: main → Folder: /docs (or your configured `outputDirectory`)
+   - ✨ GitLyte automatically creates the necessary labels (`gitlyte` and `gitlyte:preview`)
+2. **Add a label to your PR**:
+   - `gitlyte` - Generate full production site
+   - `gitlyte:preview` - Generate lightweight preview site
+3. **Merge the PR** → Your site is automatically generated!
+4. **Enable GitHub Pages** → Go to Settings > Pages > Source: Deploy from a branch → Branch: main → Folder: /docs (or your configured `outputDirectory`)
 
 That's it! GitLyte works out of the box with zero configuration.
 
@@ -36,8 +40,26 @@ GitLyte uses AI to analyze your repository and create a custom website:
 3. **Creates** Astro components with unique styling  
 4. **Deploys** to GitHub Pages automatically
 
-### 📤 Push-Based Generation (Default)
-Automatically generate sites when you push to the default branch - **no configuration needed!**
+### 🏷️ PR Merge Generation (Default)
+Automatically generate sites when you merge PRs with GitLyte labels - **no configuration needed!**
+
+- **`gitlyte`** - Generates a full production-ready site
+- **`gitlyte:preview`** - Generates a lightweight preview version (faster, uses less resources)
+
+> 💡 **Note**: These labels are automatically created when you install the GitLyte app and removed when you uninstall it.
+
+### 📤 Push-Based Generation
+For direct pushes to branches, configure in `.gitlyte.json`:
+```json
+{
+  "generation": {
+    "push": {
+      "enabled": true,
+      "branches": ["main"]
+    }
+  }
+}
+```
 
 ### 💬 Comment Commands (On-Demand)
 Use these commands in any PR comment to control generation:
@@ -64,7 +86,7 @@ Create a `.gitlyte.json` file in your repository root to customize your site:
   "generation": {
     "trigger": "auto",
     "branches": ["main"],
-    "labels": ["enhancement", "feat"],
+    "labels": ["gitlyte", "gitlyte:preview", "custom-label"],
     "outputDirectory": "docs"
   },
   "site": {
@@ -90,7 +112,7 @@ Create a `.gitlyte.json` file in your repository root to customize your site:
 #### Generation Settings
 - **trigger**: `"auto"` | `"manual"` - When to generate sites
 - **branches**: Array of branch names to generate for (empty = all branches)
-- **labels**: Required labels for automatic generation
+- **labels**: Custom labels for automatic generation (default: `["gitlyte", "gitlyte:preview"]`)
 - **outputDirectory**: Output directory for generated files (default: `"docs"`)
 
 #### Site Settings  

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.0.4/schema.json",
   "files": {
     "includes": [
       "packages/**/*.ts",
@@ -45,6 +45,18 @@
       }
     }
   },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ],
   "javascript": {
     "formatter": {
       "quoteStyle": "double",

--- a/packages/gitlyte/handlers/installation-handler.ts
+++ b/packages/gitlyte/handlers/installation-handler.ts
@@ -1,0 +1,147 @@
+import type { Context } from "probot";
+
+/** Installation event payload type */
+type InstallationPayload = {
+  installation: { id: number };
+  repositories?: Array<{
+    name: string;
+    full_name: string;
+    owner: { login: string };
+  }>;
+  repositories_added?: Array<{
+    name: string;
+    full_name: string;
+    owner: { login: string };
+  }>;
+  repositories_removed?: Array<{
+    name: string;
+    full_name: string;
+    owner: { login: string };
+  }>;
+};
+
+/** GitLyteラベルの定義 */
+const GITLYTE_LABELS = [
+  {
+    name: "gitlyte",
+    color: "667eea", // Purple
+    description: "Generate full GitLyte site on PR merge",
+  },
+  {
+    name: "gitlyte:preview",
+    color: "f093fb", // Pink
+    description: "Generate preview GitLyte site on PR merge",
+  },
+];
+
+/**
+ * アプリインストール時のハンドラ
+ * GitLyteラベルを自動作成する
+ */
+export async function handleInstallation(
+  ctx: Context<"installation" | "installation_repositories">
+) {
+  try {
+    const payload = ctx.payload as InstallationPayload;
+    const installation = payload.installation;
+    const repositories = payload.repositories || payload.repositories_added;
+    ctx.log.info(
+      `🎉 GitLyte installed for ${repositories?.length || 0} repositories`
+    );
+
+    // インストール対象のリポジトリリストを取得
+    const targetRepos =
+      repositories ||
+      (
+        await ctx.octokit.apps.listReposAccessibleToInstallation({
+          installation_id: installation.id,
+        })
+      ).data.repositories;
+
+    // 各リポジトリにラベルを作成
+    for (const repo of targetRepos) {
+      ctx.log.info(`📝 Creating labels for ${repo.full_name}`);
+
+      for (const label of GITLYTE_LABELS) {
+        try {
+          // ラベルが既に存在するかチェック
+          try {
+            await ctx.octokit.issues.getLabel({
+              owner: repo.owner.login,
+              repo: repo.name,
+              name: label.name,
+            });
+            ctx.log.info(`✅ Label "${label.name}" already exists`);
+          } catch (_error) {
+            // ラベルが存在しない場合は作成
+            await ctx.octokit.issues.createLabel({
+              owner: repo.owner.login,
+              repo: repo.name,
+              name: label.name,
+              color: label.color,
+              description: label.description,
+            });
+            ctx.log.info(`✨ Created label "${label.name}"`);
+          }
+        } catch (error) {
+          ctx.log.error(
+            `❌ Failed to create label "${label.name}" for ${repo.full_name}`,
+            error
+          );
+        }
+      }
+    }
+
+    ctx.log.info("✅ Installation completed successfully");
+  } catch (error) {
+    ctx.log.error("❌ Failed to handle installation", error);
+  }
+}
+
+/**
+ * アプリアンインストール時のハンドラ
+ * GitLyteラベルを自動削除する
+ */
+export async function handleUninstallation(
+  ctx: Context<"installation" | "installation_repositories">
+) {
+  try {
+    const payload = ctx.payload as InstallationPayload;
+    const repositories = payload.repositories || payload.repositories_removed;
+    ctx.log.info(
+      `👋 GitLyte uninstalled from ${repositories?.length || 0} repositories`
+    );
+
+    // アンインストール対象のリポジトリでラベルを削除
+    if (repositories) {
+      for (const repo of repositories) {
+        ctx.log.info(`🗑️ Removing labels from ${repo.full_name}`);
+
+        for (const label of GITLYTE_LABELS) {
+          try {
+            await ctx.octokit.issues.deleteLabel({
+              owner: repo.owner.login,
+              repo: repo.name,
+              name: label.name,
+            });
+            ctx.log.info(`🗑️ Deleted label "${label.name}"`);
+          } catch (error) {
+            const err = error as { status?: number };
+            if (err.status === 404) {
+              ctx.log.info(`⏭️ Label "${label.name}" not found, skipping`);
+            } else {
+              ctx.log.error(
+                `❌ Failed to delete label "${label.name}" from ${repo.full_name}`,
+                error
+              );
+            }
+          }
+        }
+      }
+    }
+
+    ctx.log.info("✅ Uninstallation cleanup completed");
+  } catch (error) {
+    ctx.log.error("❌ Failed to handle uninstallation", error);
+  }
+}

--- a/packages/gitlyte/index.ts
+++ b/packages/gitlyte/index.ts
@@ -2,6 +2,10 @@ import type { Probot } from "probot";
 import { handleFeaturePR } from "./handlers/pr-handler.js";
 import { handleIssueComment } from "./handlers/comment-handler.js";
 import { handlePush } from "./handlers/push-handler.js";
+import {
+  handleInstallation,
+  handleUninstallation,
+} from "./handlers/installation-handler.js";
 
 export default function app(bot: Probot) {
   // PRマージ時のハンドリング
@@ -42,4 +46,22 @@ export default function app(bot: Probot) {
     );
     await handlePush(ctx);
   });
+
+  // アプリインストール時のハンドリング
+  bot.on(
+    ["installation.created", "installation_repositories.added"],
+    async (ctx) => {
+      ctx.log.info("🎉 GitLyte app installed or repositories added");
+      await handleInstallation(ctx);
+    }
+  );
+
+  // アプリアンインストール時のハンドリング
+  bot.on(
+    ["installation.deleted", "installation_repositories.removed"],
+    async (ctx) => {
+      ctx.log.info("👋 GitLyte app uninstalled or repositories removed");
+      await handleUninstallation(ctx);
+    }
+  );
 }

--- a/packages/gitlyte/services/trigger-controller.ts
+++ b/packages/gitlyte/services/trigger-controller.ts
@@ -49,12 +49,34 @@ export class TriggerController {
       return configTrigger;
     }
 
-    // PRベースの生成は基本的に無効（Push時生成がデフォルト）
+    // デフォルトでPRマージ時の生成を有効化（GitLyte専用ラベルをチェック）
+    const prLabels = pr.labels.map((l) => l.name);
+
+    // gitlyte:preview ラベルがある場合はプレビュー生成
+    if (prLabels.includes("gitlyte:preview")) {
+      return {
+        shouldGenerate: true,
+        triggerType: "label",
+        generationType: "preview",
+        reason: "PR has gitlyte:preview label",
+      };
+    }
+
+    // gitlyte ラベルがある場合はフル生成
+    if (prLabels.includes("gitlyte")) {
+      return {
+        shouldGenerate: true,
+        triggerType: "label",
+        generationType: "full",
+        reason: "PR has gitlyte label",
+      };
+    }
+
     return {
       shouldGenerate: false,
       triggerType: "manual",
       generationType: "full",
-      reason: "PR-based generation disabled (use push or comment triggers)",
+      reason: "PR does not have gitlyte labels (gitlyte or gitlyte:preview)",
     };
   }
 

--- a/packages/gitlyte/test/handlers/installation-handler.test.ts
+++ b/packages/gitlyte/test/handlers/installation-handler.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  handleInstallation,
+  handleUninstallation,
+} from "../../handlers/installation-handler.js";
+
+describe("Installation Handler", () => {
+  let mockContext: any;
+
+  beforeEach(() => {
+    mockContext = {
+      log: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+      octokit: {
+        issues: {
+          getLabel: vi.fn(),
+          createLabel: vi.fn(),
+          deleteLabel: vi.fn(),
+        },
+        apps: {
+          listReposAccessibleToInstallation: vi.fn(),
+        },
+      },
+      payload: {},
+    };
+  });
+
+  describe("handleInstallation", () => {
+    it("should create labels for new repositories", async () => {
+      mockContext.payload = {
+        installation: { id: 123 },
+        repositories: [
+          {
+            name: "test-repo",
+            full_name: "owner/test-repo",
+            owner: { login: "owner" },
+          },
+        ],
+      };
+
+      // ラベルが存在しない場合
+      mockContext.octokit.issues.getLabel.mockRejectedValue(
+        new Error("Not found")
+      );
+
+      await handleInstallation(mockContext);
+
+      // 2つのラベルが作成されることを確認
+      expect(mockContext.octokit.issues.createLabel).toHaveBeenCalledTimes(2);
+      expect(mockContext.octokit.issues.createLabel).toHaveBeenCalledWith({
+        owner: "owner",
+        repo: "test-repo",
+        name: "gitlyte",
+        color: "667eea",
+        description: "Generate full GitLyte site on PR merge",
+      });
+      expect(mockContext.octokit.issues.createLabel).toHaveBeenCalledWith({
+        owner: "owner",
+        repo: "test-repo",
+        name: "gitlyte:preview",
+        color: "f093fb",
+        description: "Generate preview GitLyte site on PR merge",
+      });
+    });
+
+    it("should skip existing labels", async () => {
+      mockContext.payload = {
+        installation: { id: 123 },
+        repositories: [
+          {
+            name: "test-repo",
+            full_name: "owner/test-repo",
+            owner: { login: "owner" },
+          },
+        ],
+      };
+
+      // ラベルが既に存在する場合
+      mockContext.octokit.issues.getLabel.mockResolvedValue({ data: {} });
+
+      await handleInstallation(mockContext);
+
+      // ラベルが作成されないことを確認
+      expect(mockContext.octokit.issues.createLabel).not.toHaveBeenCalled();
+    });
+
+    it("should handle installation without repositories list", async () => {
+      mockContext.payload = {
+        installation: { id: 123 },
+      };
+
+      // リポジトリリストをAPIから取得
+      mockContext.octokit.apps.listReposAccessibleToInstallation.mockResolvedValue(
+        {
+          data: {
+            repositories: [
+              {
+                name: "test-repo",
+                full_name: "owner/test-repo",
+                owner: { login: "owner" },
+              },
+            ],
+          },
+        }
+      );
+
+      mockContext.octokit.issues.getLabel.mockRejectedValue(
+        new Error("Not found")
+      );
+
+      await handleInstallation(mockContext);
+
+      expect(
+        mockContext.octokit.apps.listReposAccessibleToInstallation
+      ).toHaveBeenCalledWith({
+        installation_id: 123,
+      });
+      expect(mockContext.octokit.issues.createLabel).toHaveBeenCalledTimes(2);
+    });
+
+    it("should handle errors gracefully", async () => {
+      mockContext.payload = {
+        installation: { id: 123 },
+        repositories: [
+          {
+            name: "test-repo",
+            full_name: "owner/test-repo",
+            owner: { login: "owner" },
+          },
+        ],
+      };
+
+      // エラーが発生した場合
+      mockContext.octokit.issues.getLabel.mockRejectedValue(
+        new Error("API Error")
+      );
+      mockContext.octokit.issues.createLabel.mockRejectedValue(
+        new Error("Create failed")
+      );
+
+      await handleInstallation(mockContext);
+
+      expect(mockContext.log.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("handleUninstallation", () => {
+    it("should delete labels from repositories", async () => {
+      mockContext.payload = {
+        repositories: [
+          {
+            name: "test-repo",
+            full_name: "owner/test-repo",
+            owner: { login: "owner" },
+          },
+        ],
+      };
+
+      await handleUninstallation(mockContext);
+
+      // 2つのラベルが削除されることを確認
+      expect(mockContext.octokit.issues.deleteLabel).toHaveBeenCalledTimes(2);
+      expect(mockContext.octokit.issues.deleteLabel).toHaveBeenCalledWith({
+        owner: "owner",
+        repo: "test-repo",
+        name: "gitlyte",
+      });
+      expect(mockContext.octokit.issues.deleteLabel).toHaveBeenCalledWith({
+        owner: "owner",
+        repo: "test-repo",
+        name: "gitlyte:preview",
+      });
+    });
+
+    it("should handle missing labels gracefully", async () => {
+      mockContext.payload = {
+        repositories: [
+          {
+            name: "test-repo",
+            full_name: "owner/test-repo",
+            owner: { login: "owner" },
+          },
+        ],
+      };
+
+      // ラベルが存在しない場合（404エラー）
+      const notFoundError = new Error("Not found") as Error & {
+        status: number;
+      };
+      notFoundError.status = 404;
+      mockContext.octokit.issues.deleteLabel.mockRejectedValue(notFoundError);
+
+      await handleUninstallation(mockContext);
+
+      expect(mockContext.log.info).toHaveBeenCalledWith(
+        expect.stringContaining("not found, skipping")
+      );
+    });
+
+    it("should handle no repositories gracefully", async () => {
+      mockContext.payload = {};
+
+      await handleUninstallation(mockContext);
+
+      expect(mockContext.octokit.issues.deleteLabel).not.toHaveBeenCalled();
+      expect(mockContext.log.info).toHaveBeenCalledWith(
+        expect.stringContaining("uninstalled from 0 repositories")
+      );
+    });
+
+    it("should handle deletion errors", async () => {
+      mockContext.payload = {
+        repositories: [
+          {
+            name: "test-repo",
+            full_name: "owner/test-repo",
+            owner: { login: "owner" },
+          },
+        ],
+      };
+
+      // 削除エラー（404以外）
+      mockContext.octokit.issues.deleteLabel.mockRejectedValue(
+        new Error("API Error")
+      );
+
+      await handleUninstallation(mockContext);
+
+      expect(mockContext.log.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/gitlyte/test/services/trigger-controller.test.ts
+++ b/packages/gitlyte/test/services/trigger-controller.test.ts
@@ -39,10 +39,10 @@ describe("TriggerController", () => {
       expect(result.reason).toBe("Config-based label generation");
     });
 
-    it("should not generate when no labels are configured", async () => {
+    it("should generate full site when PR has gitlyte label", async () => {
       const pr = {
         ...mockPR,
-        labels: [{ name: "enhancement" }],
+        labels: [{ name: "gitlyte" }],
       };
 
       const config = {
@@ -56,14 +56,36 @@ describe("TriggerController", () => {
         config
       );
 
-      expect(result.shouldGenerate).toBe(false);
-      expect(result.triggerType).toBe("manual");
-      expect(result.reason).toBe(
-        "PR-based generation disabled (use push or comment triggers)"
-      );
+      expect(result.shouldGenerate).toBe(true);
+      expect(result.triggerType).toBe("label");
+      expect(result.generationType).toBe("full");
+      expect(result.reason).toBe("PR has gitlyte label");
     });
 
-    it("should not generate when required labels are missing (PR-based generation disabled by default)", async () => {
+    it("should generate preview when PR has gitlyte:preview label", async () => {
+      const pr = {
+        ...mockPR,
+        labels: [{ name: "gitlyte:preview" }],
+      };
+
+      const config = {
+        generation: {
+          // labels 設定なし
+        },
+      };
+
+      const result = await triggerController.shouldGenerateOnPRMerge(
+        pr,
+        config
+      );
+
+      expect(result.shouldGenerate).toBe(true);
+      expect(result.triggerType).toBe("label");
+      expect(result.generationType).toBe("preview");
+      expect(result.reason).toBe("PR has gitlyte:preview label");
+    });
+
+    it("should not generate when PR doesn't have gitlyte labels", async () => {
       const pr = {
         ...mockPR,
         labels: [{ name: "documentation" }],
@@ -77,7 +99,7 @@ describe("TriggerController", () => {
       expect(result.shouldGenerate).toBe(false);
       expect(result.triggerType).toBe("manual");
       expect(result.reason).toBe(
-        "PR-based generation disabled (use push or comment triggers)"
+        "PR does not have gitlyte labels (gitlyte or gitlyte:preview)"
       );
     });
   });


### PR DESCRIPTION
# 概要

GitLyteのデフォルトトリガーをPRマージベースに変更し、アプリインストール時のラベル自動管理機能を追加しました。

## 変更内容

保護されたブランチへの直接push制限に対応し、より一般的なワークフローをサポートします。

### 1. PRマージトリガーの実装
- `gitlyte`ラベル: 本番用のフルサイト生成
- `gitlyte:preview`ラベル: プレビュー用の軽量版生成
- 保護ブランチでも問題なく動作

### 2. ラベル自動管理機能
- アプリインストール時に必要なラベルを自動作成
- アンインストール時にGitLyteラベルを自動削除
- ユーザーの手間を大幅に削減

### 3. ドキュメント更新
- READMEにGitLyteラベルの使用方法を記載
- ラベル自動作成についての説明を追加

## 関連情報

- ユーザーからのフィードバック: 「デフォルトブランチはpush制限がついていることが多い」
- より使いやすいデフォルト設定への改善

🤖 Generated with [Claude Code](https://claude.ai/code)