### PR TITLE
Document: Astroへの参照を削除し静的HTML生成に更新

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ pnpm start
 ```sh
 pnpm run build       # Build all packages
 pnpm start           # Start the GitHub App (requires .env setup)
-pnpm run dev:demo    # Start demo Astro development server
+pnpm run dev:demo    # Start demo development server
 ```
 
 ### Code Quality

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A GitHub App built with [Probot](https://github.com/probot/probot) that automati
 ## ✨ Features
 
 - 🤖 **AI-Powered Design**: Analyzes your repository and generates custom designs
-- 🚀 **Astro-Based Sites**: Modern, fast static sites with excellent performance
+- 🚀 **Static HTML Sites**: Modern, fast static sites with excellent performance
 - 🎨 **Unique Styling**: Every site gets a custom color scheme and layout
 - 📱 **Responsive Design**: Looks great on all devices
 - ⚡ **Auto-Deploy**: GitHub Actions automatically build and deploy
@@ -37,7 +37,7 @@ GitLyte uses AI to analyze your repository and create a custom website:
 
 1. **Analyzes** your repository (tech stack, purpose, audience)
 2. **Generates** a custom design strategy with AI
-3. **Creates** Astro components with unique styling  
+3. **Creates** HTML pages with unique styling  
 4. **Deploys** to GitHub Pages automatically
 
 ### 🏷️ PR Merge Generation (Default)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,14 +1,14 @@
 # GitLyte Architecture
 
-GitLyte is a GitHub App built with [Probot](https://github.com/probot/probot) that automatically generates AI-powered Astro websites from repository data. This document provides a detailed technical overview of the system architecture.
+GitLyte is a GitHub App built with [Probot](https://github.com/probot/probot) that automatically generates AI-powered static HTML websites from repository data. This document provides a detailed technical overview of the system architecture.
 
 ## 🏗 System Architecture
 
 ```
 GitHub Events → AI Analysis → Custom Site Generation → GitHub Pages Deploy
      ↓             ↓              ↓                    ↓
-  PR/Issue      OpenAI API     Astro Components    Static Site
-  Content       Design AI      Custom CSS/JS       Auto-Deploy
+  PR/Issue      Anthropic API   HTML/CSS/JS        Static Site
+  Content       Design AI       Custom Pages       Auto-Deploy
 ```
 
 ## 📁 Project Structure
@@ -16,7 +16,7 @@ GitHub Events → AI Analysis → Custom Site Generation → GitHub Pages Deploy
 GitLyte uses pnpm workspaces with two main packages:
 
 - `@gitlyte/core` - Main GitHub App in `packages/gitlyte/`
-- `@gitlyte/demo` - Demo Astro application in `packages/demo/`
+- `@gitlyte/demo` - Demo site example in `packages/demo/`
 
 ```
 packages/
@@ -47,7 +47,7 @@ The architecture follows a three-stage AI pipeline:
 - **Comment commands** (`@gitlyte generate`, `@gitlyte preview`)
 
 ### 2. AI Analysis
-Repository is analyzed using OpenAI API to determine:
+Repository is analyzed using Anthropic Claude API to determine:
 - Project type and tech stack
 - Target audience
 - Purpose and tone
@@ -61,7 +61,7 @@ AI creates custom design strategy:
 - Component styling
 
 ### 4. Code Generation
-Astro components are generated with:
+HTML pages are generated with:
 - Custom styling (no templates)
 - Project-specific content
 - Responsive design
@@ -87,7 +87,7 @@ Files are batch-committed and deployed:
 **File**: `packages/gitlyte/services/repository-analyzer.ts`
 - Analyzes repository structure and content
 - Determines project characteristics
-- Generates design strategy using OpenAI
+- Generates design strategy using Anthropic Claude
 
 #### Site Generator
 **File**: `packages/gitlyte/services/site-generator.ts`

--- a/docs/IMPLEMENTATION_GUIDE.md
+++ b/docs/IMPLEMENTATION_GUIDE.md
@@ -52,7 +52,7 @@ packages/gitlyte/
 services/
 ├── ai-content-generator.ts       # ❌ DELETE: 新アーキテクチャで置換
 ├── ai-code-generator.ts          # ❌ DELETE: 新アーキテクチャで置換
-├── astro-generator.ts            # ❌ DELETE: 静的生成に変更
+├── astro-generator.ts            # ❌ DELETE: HTML生成に変更
 ├── ai-analyzer.ts                # ❌ DELETE: repository-analyzer.tsで置換
 ├── docs-generator.ts             # ❌ DELETE: site-generator.tsに統合
 └── hybrid-generator.ts           # ❌ DELETE: 不要
@@ -134,7 +134,7 @@ export class RepositoryAnalyzer {
   }
   
   private async analyzeWithAI(repoData: RepoData): Promise<AIAnalysisResult> {
-    // OpenAI API call for intelligent analysis
+    // Anthropic Claude API call for intelligent analysis
   }
   
   private async extractCodeFeatures(repoData: RepoData): Promise<CodeFeatures> {

--- a/packages/gitlyte/services/ai-site-architect.ts
+++ b/packages/gitlyte/services/ai-site-architect.ts
@@ -338,7 +338,7 @@ export async function generateComponentSpecs(
   repoData: RepoData
 ): Promise<ComponentSpec[]> {
   const prompt = `
-あなたは革新的なWebコンポーネント設計の専門家です。以下の詳細なセクション設計から、完全オリジナルのAstroコンポーネントを作成してください。
+あなたは革新的なWebコンポーネント設計の専門家です。以下の詳細なセクション設計から、完全オリジナルのHTMLコンポーネントを作成してください。
 
 ## サイト全体のコンセプト
 - テーマ: ${architecture.concept.theme}
@@ -372,7 +372,7 @@ export async function generateComponentSpecs(
     "name": "コンポーネント名",
     "purpose": "コンポーネントの目的と役割",
     "props_interface": "export interface Props { ... }の完全な型定義",
-    "html_structure": "Astroコンポーネントの完全なHTML構造（propsを使用）",
+    "html_structure": "HTMLコンポーネントの完全な構造（変数を使用）",
     "css_styles": "コンポーネント専用の完全なCSS（CSS変数を活用）",
     "responsive_rules": "レスポンシブデザインの詳細なルール"
   }


### PR DESCRIPTION
# 概要

ドキュメント全体でAstroへの参照を削除し、現在の実装に合わせて静的HTML生成として記載を更新しました。

## 変更内容

GitLyteは現在Astroを使用していないため、全てのドキュメントを更新しました。

- README.md: "Astro-Based Sites" → "Static HTML Sites"に変更
- CONTRIBUTING.md: "demo Astro development server" → "demo development server"に変更
- docs/ARCHITECTURE.md: Astro参照を全てHTML/CSS/JSに変更、OpenAI→Anthropic更新
- docs/IMPLEMENTATION_GUIDE.md: Astro参照をHTML生成に変更
- packages/gitlyte/services/ai-site-architect.ts: 日本語プロンプトで"Astroコンポーネント" → "HTMLコンポーネント"に変更

## 関連情報

- ユーザーからの指摘により、Astroが使用されていないことが判明
- 現在は静的HTML/CSS/JSファイルを直接生成する実装となっている

🤖 Generated with [Claude Code](https://claude.ai/code)