### PR TITLE
ci: add GitLyte site generation workflows

### DIFF
--- a/.github/workflows/gitlyte-high.yml
+++ b/.github/workflows/gitlyte-high.yml
@@ -1,0 +1,39 @@
+name: Generate Site with GitLyte (High Quality)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Site
+        uses: wadakatu/gitlyte@v1.2.0
+        with:
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          provider: anthropic
+          quality: high
+          output-directory: docs
+          theme-mode: dark
+          theme-toggle: true
+          site-url: https://wadakatu.github.io/gitlyte
+          generate-sitemap: true
+          generate-robots: true
+          show-stats: true
+          fetch-contributors: true
+          fetch-releases: true
+          generate-contributors-page: true
+          max-contributors: 100
+
+      - name: Commit and Push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          git diff --staged --quiet || git commit -m "chore: update GitLyte generated site"
+          git push

--- a/.github/workflows/gitlyte-standard.yml
+++ b/.github/workflows/gitlyte-standard.yml
@@ -1,0 +1,39 @@
+name: Generate Site with GitLyte (Standard)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Site
+        uses: wadakatu/gitlyte@v1.2.0
+        with:
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          provider: anthropic
+          quality: standard
+          output-directory: docs
+          theme-mode: dark
+          theme-toggle: true
+          site-url: https://wadakatu.github.io/gitlyte
+          generate-sitemap: true
+          generate-robots: true
+          show-stats: true
+          fetch-contributors: true
+          fetch-releases: true
+          generate-contributors-page: true
+          max-contributors: 100
+
+      - name: Commit and Push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          git diff --staged --quiet || git commit -m "chore: update GitLyte generated site"
+          git push


### PR DESCRIPTION
## Summary
- Add two workflow files for manual site generation using GitLyte v1.2.0
- `gitlyte-standard.yml`: Standard quality mode (faster, lower cost)
- `gitlyte-high.yml`: High quality mode (better design, more iterations)

## Features Enabled
- Dark theme with light/dark toggle
- SEO settings with sitemap.xml and robots.txt
- GitHub statistics display (stars, forks, watchers, etc.)
- Contributors page generation (up to 100 contributors)

## Test plan
- [ ] Merge PR and run workflow manually from Actions tab
- [ ] Verify generated site in `docs/` directory
- [ ] Check contributors page and stats display

🤖 Generated with [Claude Code](https://claude.com/claude-code)